### PR TITLE
Use env shebang for better compatibility

### DIFF
--- a/ubuntu-18.04.sh
+++ b/ubuntu-18.04.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!usr/bin/env bash
 
 start=`date +%s`
 


### PR DESCRIPTION
Improves compatibility with distros with different PATHs. Had to make this change for an Ubuntu 20.04 machine.