### PR TITLE
fixes a python3 install issue in Ubuntu 22.04

### DIFF
--- a/ubuntu-20.04.sh
+++ b/ubuntu-20.04.sh
@@ -7,6 +7,13 @@ sudo apt-get -y update
 sudo apt-get -y upgrade
 sudo apt-get -y dist-upgrade
 
+# avoid fresh Ubuntu bug that prevented Jesse from installing, see: 
+# https://bugs.launchpad.net/ubuntu/+source/distro-info/+bug/1991606
+# https://github.com/pypa/setuptools/issues/3772
+if [[ $(lsb_release -rs) == "22.04" ]]; then 
+      sudo apt autoremove python3-debian python3-distro-info
+fi
+
 # python 3.x extensions
 echo "installing Python 3.x extensions ..."
 sudo apt-get -y install gcc binutils


### PR DESCRIPTION
I'm installing Jesse on a clean Ubuntu 22.04, and was getting the following error:
`      pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '1.1build1' (package: distro-info)`

Upon some research, turned out there's some compatibility issue between new setuptools and python: https://github.com/pypa/setuptools/issues/3772
https://bugs.launchpad.net/ubuntu/+source/distro-info/+bug/1991606

Adding `sudo apt autoremove python3-debian python3-distro-info` fixed that.