### PR TITLE
ez_setup needs older version of setuptools

### DIFF
--- a/ubuntu-20.04.sh
+++ b/ubuntu-20.04.sh
@@ -15,7 +15,7 @@ sudo apt-get -y install python3-dev python3-pip python3-setuptools
 sudo apt-get -y install build-essential
 sudo -H pip3 install --upgrade pip
 hash -d pip3
-pip3 install --upgrade setuptools
+pip3 install setuptools==65.5.0
 pip3 install ez_setup
 pip3 install numpy==1.23.0 Cython
 

--- a/ubuntu-22.04.sh
+++ b/ubuntu-22.04.sh
@@ -18,7 +18,7 @@ sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 
 sudo apt-get -y install build-essential
 sudo -H pip3 install --upgrade pip
 hash -d pip3
-pip3 install --upgrade setuptools
+pip3 install setuptools==65.5.0
 pip3 install ez_setup
 pip3 install numpy==1.23.0 Cython
 


### PR DESCRIPTION
This pull request addresses a compatibility issue between the ez_setup package and the latest versions of setuptools. The error occurs because the canonicalize_version function in setuptools no longer supports the strip_trailing_zero argument, resulting in a failure when attempting to install ez_setup.

Testing:
Tested on a fresh Linux server with Python 3.11.
Confirmed that the installer runs without errors after removing the outdated ez_setup dependency.

```
root@remotejesse:~# pip show jesse
Name: jesse
Version: 1.3.16
Summary: A trading framework for cryptocurrencies
Home-page: https://jesse.trade
Author: Saleh Mir
Author-email: saleh@jesse.trade
License:
Location: /usr/local/lib/python3.11/dist-packages
Requires: aiofiles, aioredis, arrow, blinker, click, cryptography, fastapi, fnc, jesse-dydx-v3-python, matplotlib, mplfinance, newtulipy, numba, numpy, numpy-groupies, pandas, peewee, psycopg2-binary, pydash, PyJWT, pytest, python-dotenv, PyWavelets, quantstats, redis, requests, scipy, simplejson, statsmodels, TA-Lib, tabulate, timeloop, uvicorn, websocket-client, websockets, wsaccel
```

Let me know if any further changes or additional testing are required!